### PR TITLE
Switch the header style on live feed page to match rest of site

### DIFF
--- a/localore/home/templates/home/live_feed_page.html
+++ b/localore/home/templates/home/live_feed_page.html
@@ -8,14 +8,15 @@
 
 <div class="container-full">
 
-	<section class="live-feed" id="livefeed">
-		<div class="container">
-			<h4>Live Feed</h4>
-			{% if page.live_feed_intro %}
-			{{ page.live_feed_intro|richtext }}
-			{% endif %}
+	<div id="title" class="title title-about">
+		<div>
+			<h1>{{ page.title }}</h1>
 		</div>
-	</section>
+	</div>
+
+	{% if page.live_feed_intro %}
+		<div class="description">{{ page.live_feed_intro|richtext }}</div>
+	{% endif %}
 
 	{% with juicer_feed_id=settings.localore_admin.JuicerSettings.juicer_feed_id %}
 	{% if juicer_feed_id %}

--- a/localore/localore/static/sass/_base.scss
+++ b/localore/localore/static/sass/_base.scss
@@ -127,7 +127,7 @@ body {
 
   .rich-text {
     @include outer-container($grid-md);
-    width: 75%;
+    width: 80%;
     position: absolute;
     bottom: 25px;
     left: 50%;
@@ -162,7 +162,7 @@ body {
   }
 
   @include media($mobile) {
-    background-size: 200%;
+    background-size: 225%;
   }
 
 


### PR DESCRIPTION
This matches the header style on the Live Feed page:

![screen shot 2018-07-08 at 5 06 33 pm](https://user-images.githubusercontent.com/627751/42423995-e543de00-82d1-11e8-99e4-8ae75a1cd339.png)
<img width="375" alt="screen shot 2018-07-08 at 5 08 58 pm" src="https://user-images.githubusercontent.com/627751/42423999-e7e78008-82d1-11e8-833c-4020e05d9b5e.png">

@LindseyWagner to review attached screenshots or a demo version?